### PR TITLE
fix: set a solid background on the floating toolbar (#9)

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -58,7 +58,12 @@ exports.postToolbarInit = (hook, context) => {
     }
   });
   const padOuter = $('iframe[name="ace_outer"]').contents().find('body');
-  $('#inline_toolbar').css('background-color', 'transparent');
-  $('#inline_toolbar').css('opacity', '0.8');
+  // The floating toolbar is detached into the ace_outer iframe, which does
+  // not load the main page's `.toolbar` stylesheet. Previously the JS
+  // hard-coded `background-color: transparent`, so the toolbar had no
+  // background at all once detached and the icons appeared to float over
+  // the pad text (regression for #9). Set a solid background so the
+  // toolbar is legible.
+  $('#inline_toolbar').css('background-color', '#ffffff');
   $('#inline_toolbar').detach().appendTo(padOuter[0]);
 };

--- a/static/tests/backend/specs/background_fix.js
+++ b/static/tests/backend/specs/background_fix.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+
+const indexPath = path.resolve(__dirname, '..', '..', '..', '..', 'static', 'js', 'index.js');
+
+describe(__filename, function () {
+  it('postToolbarInit no longer forces background-color: transparent (#9)', function () {
+    const src = fs.readFileSync(indexPath, 'utf8');
+    // Strip comments before scanning so explanatory text doesn't trip the
+    // check. The real bug was a `.css('background-color', 'transparent')`
+    // call in the postToolbarInit hook body.
+    const code = src
+        .replace(/\/\/[^\n]*/g, '')
+        .replace(/\/\*[\s\S]*?\*\//g, '');
+    const badCall = /\.css\(\s*['"]background-color['"]\s*,\s*['"]transparent['"]\s*\)/;
+    assert(!badCall.test(code),
+        'index.js must not force a transparent background on #inline_toolbar, which left the ' +
+        'floating toolbar invisible when detached into the ace_outer iframe');
+    assert(/#inline_toolbar['"\s\S]{0,200}background-color/.test(code),
+        'index.js should explicitly set a background-color on #inline_toolbar so it is visible ' +
+        'in the ace_outer iframe where the default .toolbar stylesheet is not loaded');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #9: the inline toolbar had no visible background, so the icons appeared to float over the pad text without any container.
- Root cause: \`postToolbarInit\` hard-coded \`background-color: transparent\` on \`#inline_toolbar\` and then detached it into the \`ace_outer\` iframe. That iframe does not load the main page's \`.toolbar\` stylesheet, so the transparent override left the toolbar completely background-less.
- Replace the transparent call with an explicit white background. Also drops the stray \`opacity: 0.8\` override that was faded over the (missing) background.

## Test plan
- [x] Backend spec asserts there is no \`\\.css('background-color', 'transparent')\` call on \`#inline_toolbar\` and that some \`background-color\` rule is set for \`#inline_toolbar\`.