### PR TITLE
fix: clone buttons into inline toolbar so main editbar stays populated (#10 #11 #66)

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -50,12 +50,21 @@ exports.postToolbarInit = (hook, context) => {
   }
   $('#editbar .menu_left').children('[data-key]').each(function () {
     const key = $(this).data('key');
-    if (buttonsToShow.indexOf(key) !== -1) {
-      $('#inline_toolbar_menu_items').append(this);
-    } else {
-      $('#inline_toolbar_menu_items').append(this);
-      $(this).css('display', 'none');
-    }
+    if (buttonsToShow.indexOf(key) === -1) return;
+    // Clone the button into the inline toolbar instead of moving it: the
+    // previous logic called `.append(this)` which *moves* the DOM node,
+    // so every toolbar item ended up inside #inline_toolbar_menu_items and
+    // the main toolbar was left empty (regression for #10, #11, #66).
+    // We re-bind the click on the clone because jQuery's event-cloning
+    // depends on `withDataAndEvents` support that the registered toolbar
+    // commands don't opt into.
+    const $original = $(this);
+    const $clone = $original.clone();
+    $clone.on('click', (evt) => {
+      evt.preventDefault();
+      $original.trigger('click');
+    });
+    $('#inline_toolbar_menu_items').append($clone);
   });
   const padOuter = $('iframe[name="ace_outer"]').contents().find('body');
   $('#inline_toolbar').css('background-color', 'transparent');

--- a/static/tests/backend/specs/main_toolbar_preserved.js
+++ b/static/tests/backend/specs/main_toolbar_preserved.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+
+const indexPath = path.resolve(__dirname, '..', '..', '..', '..', 'static', 'js', 'index.js');
+
+describe(__filename, function () {
+  it('postToolbarInit clones buttons instead of moving them (regression #10 #11 #66)',
+      function () {
+        const src = fs.readFileSync(indexPath, 'utf8');
+        const postToolbar = src.match(/exports\.postToolbarInit\s*=\s*[\s\S]*?\n\};/);
+        assert(postToolbar, 'expected postToolbarInit export in static/js/index.js');
+        const body = postToolbar[0];
+        // The original bug was `.append(this)` inside the `.each` loop, which
+        // moves the <li> out of the main editbar and leaves it empty. The
+        // only append we allow now must operate on a clone ("$clone" or
+        // similar), not on "this".
+        assert(!/#inline_toolbar_menu_items['"]\)\.append\(this\)/.test(body),
+            'postToolbarInit must not .append(this) into #inline_toolbar_menu_items — that moves ' +
+            'the buttons out of the main editbar. Clone them instead.');
+        assert(/\.clone\(/.test(body),
+            'postToolbarInit should use .clone() so the main toolbar keeps its buttons');
+      });
+
+  it('does not hide buttons that are absent from the inline toolbar config', function () {
+    const src = fs.readFileSync(indexPath, 'utf8');
+    const postToolbar = src.match(/exports\.postToolbarInit\s*=\s*[\s\S]*?\n\};/);
+    const body = postToolbar[0];
+    // Previous code called `.css('display', 'none')` on every button not in
+    // the config, which caused main-toolbar buttons to vanish when the
+    // plugin was active (#10, #66).
+    assert(!/\.css\(\s*['"]display['"]\s*,\s*['"]none['"]\s*\)/.test(body),
+        'postToolbarInit must not hide main-toolbar buttons with display:none');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #10, #11, #66.
- \`postToolbarInit\` called \`.append(this)\` in a \`.each\` loop over \`#editbar .menu_left [data-key]\`, which *moves* the \`<li>\` out of the main editbar. The main toolbar ended up empty regardless of the user's \`settings.toolbar.left\` config. Buttons that were absent from the inline toolbar config got moved into \`#inline_toolbar_menu_items\` and hidden with \`display:none\`, so uninstalling the plugin also left the editbar visually broken until a refresh.
- Clone the desired buttons into the inline toolbar, leave the originals in place, and re-bind \`click\` on each clone to forward to the original element. The main toolbar now retains every button configured in \`toolbar.left\`, and removing the plugin no longer leaves the editbar mutated.

## Test plan
- [x] Backend spec asserts \`postToolbarInit\` no longer calls \`.append(this)\` on \`#inline_toolbar_menu_items\`, uses \`.clone(\` on the buttons, and no longer hides anything with \`display:none\`.