### PR TITLE
refactor: adopt template helper for 2 simple eejsBlock_* hook(s)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {template} = require('ep_plugin_helpers');
+
 const eejs = require('ep_etherpad-lite/node/eejs/');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
 
@@ -14,15 +16,11 @@ exports.clientVars = (hookName, context, callback) => {
   });
 };
 
-exports.eejsBlock_body = (hookName, args, cb) => {
-  args.content += eejs.require('ep_inline_toolbar/templates/menuButtons.ejs');
-  cb();
-};
+exports.eejsBlock_body =
+    template('ep_inline_toolbar/templates/menuButtons.ejs');
 
-exports.eejsBlock_mySettings = (hookName, args, cb) => {
-  args.content += eejs.require('ep_inline_toolbar/templates/settings.ejs');
-  cb();
-};
+exports.eejsBlock_mySettings =
+    template('ep_inline_toolbar/templates/settings.ejs');
 
 exports.eejsBlock_scripts = (hookName, args, cb) => {
   cb();

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix ."
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.5.0"
   }
 }


### PR DESCRIPTION
## Summary

Adopts the `template()` helper from `ep_plugin_helpers` for 2 `eejsBlock_*` hook(s) that match the strict-simple shape:

```js
exports.eejsBlock_X = (hookName, args, cb) => {
  args.content += eejs.require('plugin/template.ejs');
  cb();
};
```

Replaced with:

```js
exports.eejsBlock_X = template('plugin/template.ejs');
```

Same runtime behavior — eejs renders the same template into the same section. The helper just removes per-plugin re-implementation of the `args.content += eejs.require(...)` boilerplate.

## Out of scope

Hooks with vars, conditional skip logic, or non-eejs content (e.g. raw `<script>` tags being concatenated) are left alone — those need either the helper's `vars`/`skip` callbacks or different helper variants. Part of Phase 4 of the modernization campaign (pilot: ether/ep_align#182, ether/ep_themes#103).