### PR TITLE
refactor: adopt template helper for 1 simple eejsBlock_* hook(s)

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,5 @@ exports.eejsBlock_scripts = (hookName, args, cb) => {
 
 
 // not used
-exports.eejsBlock_styles = (hookName, args, cb) => {
-  args.content += eejs.require('ep_inline_toolbar/templates/styles.html', {}, module);
-  cb();
-};
+exports.eejsBlock_styles =
+    template('ep_inline_toolbar/templates/styles.html');


### PR DESCRIPTION
## Summary

Adopts `template()` from `ep_plugin_helpers` for 1 `eejsBlock_*` hook(s) of shape:

```js
exports.eejsBlock_X = (hookName, args, cb) => {
  args.content += eejs.require('plugin/template.ejs'[, {}[, module]]);
  cb();
};
```

Replaced with `exports.eejsBlock_X = template('plugin/template.ejs');`. Same runtime behavior.

Part of Phase 4 of the modernization campaign. Wave 1: ether/ep_themes#103 + 6 small plugins. Wave 2 picks up hooks with explicit empty-vars / module argument that wave 1's stricter regex skipped.